### PR TITLE
phppgadmin: do not expose port 443

### DIFF
--- a/phppgadmin/Dockerfile
+++ b/phppgadmin/Dockerfile
@@ -53,6 +53,6 @@ ENV POSTGRES_DEFAULTDB defaultdb
 ENV POSTGRES_HOST localhost
 ENV POSTGRES_PORT 5432
 
-EXPOSE 80 443
+EXPOSE 80
 COPY start.sh /start.sh
 CMD ["bash", "start.sh"]


### PR DESCRIPTION
Exposing port 443 makes some PaaS try to monitor the health state.
However HTTPS is not configured currently for this image, therefore the
health check for this port will fail.